### PR TITLE
add hint for releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can find all published releases on the Releases page
 
 1. Navigate to Releases at https://github.com/RoboCup-SSL/ssl-status-board/releases.
 
-2. Find the version you want and download the asset labelled something like ssl-status-board-`<version>`-`<os-arch>`
+2. Find the version you want and download the asset labelled something like ssl-status-board_`<version>`_`<os-arch>`
 
 3. On Linux/MacOS/Windows, open a terminal and run the binary 
 You might need to mark it executable on Linux/Mac: 


### PR DESCRIPTION
A reference to the releases in the readme would be useful. These are often overlooked, resulting in unnecessary extra work.